### PR TITLE
Catch select.error in _AsyncRead

### DIFF
--- a/pyads/adsclient.py
+++ b/pyads/adsclient.py
@@ -78,19 +78,19 @@ class AdsClient:
     def _AsyncRead(self):
 
         while self.IsConnected:
-            ready = select.select([self.Socket], [], [], 0.1)
+            try:
+                ready = select.select([self.Socket], [], [], 0.1)
 
-            if ready[0] and self.IsConnected:
-                try:
-                    newPacket = self.ReadAmsPacketFromSocket()
-                    if (newPacket.InvokeID == self._CurrentInvokeID):
-                        self._CurrentPacket = newPacket
-                    else:
-                        print("Packet dropped:")
-                        print(newPacket)
-                except socket.error:
-                    self.Close()
-                    break
+                if ready[0] and self.IsConnected:
+                        newPacket = self.ReadAmsPacketFromSocket()
+                        if (newPacket.InvokeID == self._CurrentInvokeID):
+                            self._CurrentPacket = newPacket
+                        else:
+                            print("Packet dropped:")
+                            print(newPacket)
+            except (socket.error, select.error):
+                self.Close()
+                break
 
 
 


### PR DESCRIPTION
Hi @chwiede,

I get this error using ```pyads```:  
```
Nov 22 01:09:37 cazzolla python[17578]: Exception in thread Thread-49682:
Nov 22 01:09:37 cazzolla python[17578]: Traceback (most recent call last):
Nov 22 01:09:37 cazzolla python[17578]: File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
Nov 22 01:09:37 cazzolla python[17578]: # _sys) in case sys.stderr was redefined since the creation of
Nov 22 01:09:37 cazzolla python[17578]: File "/usr/lib/python2.7/threading.py", line 763, in run
Nov 22 01:09:37 cazzolla python[17578]: # happen when a daemon thread wakes up at an unfortunate
Nov 22 01:09:37 cazzolla python[17578]: File "/usr/local/lib/python2.7/dist-packages/pyads/adsclient.py", line 81, in _AsyncRead
Nov 22 01:09:37 cazzolla python[17578]: ready = select.select([self.Socket], [], [], 0.1)
Nov 22 01:09:37 cazzolla python[17578]: File "/usr/lib/python2.7/socket.py", line 224, in meth
Nov 22 01:09:37 cazzolla python[17578]: type = property(lambda self: self._sock.type, doc="the socket type")
Nov 22 01:09:37 cazzolla python[17578]: File "/usr/lib/python2.7/socket.py", line 170, in _dummy
Nov 22 01:09:37 cazzolla python[17578]: error: [Errno 9] Bad file descriptor
```

This patch should solve the issue.